### PR TITLE
Update build-custom-glclient.sh

### DIFF
--- a/scripts/build-custom-glclient.sh
+++ b/scripts/build-custom-glclient.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ ! $GLCLIENT_INSTALL_DIR ];then
   GLCLIENT_INSTALL_DIR=/usr/share/globaleaks/glclient


### PR DESCRIPTION
Using /bin/bash is almost always wrong.
Using /bin/sh is almost always correct
Using /usr/bin/env bash is better than /bin/bash

Consider cases where
a) /bin/bash is non-existent (most unixes)
b) /bin/bash is outdated (OSX)

I have not tested this with a POSIX shell but quickly skimmed it.

In addition get_sudo seems buggy: it can and should use "su" when sudo is not around.
