### PR TITLE
Port forwarding

### DIFF
--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -31,7 +31,10 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network :forwarded_port, guest: 80, host: 8080
-
+  
+  # Forward globaleaks daemon port to get access from localhost
+  config.vm.network :forwarded_port, guest: 8082, host: 8082
+  
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # config.vm.network :private_network, ip: "192.168.33.10"


### PR DESCRIPTION
Adding 8082 port forward to be able to access to globaleaks from localhost without know the VM ip, and without have an internet connection to use onion address.
