### PR TITLE
Port forwarding

### DIFF
--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -32,6 +32,9 @@ Vagrant.configure("2") do |config|
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network :forwarded_port, guest: 80, host: 8080
 
+  # Forward globaleaks daemon port to get access from localhost
+  config.vm.network :forwarded_port, guest: 8082, host: 8082 
+
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
   # config.vm.network :private_network, ip: "192.168.33.10"


### PR DESCRIPTION
Adding 8082 port forward to be able to access to globaleaks from localhost without knowledge of the VM IP address, and without have an internet connection to use onion address.
