### PR TITLE
Adding hebrew to stylesheet chooser for RTL

### DIFF
--- a/client/app/scripts/controllers/main.js
+++ b/client/app/scripts/controllers/main.js
@@ -111,7 +111,7 @@ GLClient.controller('MainCtrl', ['$scope', '$rootScope', '$http', '$route', '$ro
 
         $translate.use($rootScope.language);
 
-        if (newVal != "ar") {
+        if (newVal != "ar" && newVal != "he") {
           $scope.build_stylesheet = "/styles.css";
         } else {
           $scope.build_stylesheet = "/styles-rtl.css";


### PR DESCRIPTION
The RTL stylesheet was only being loaded for arabic, it should now also load for hebrew.
