### PR TITLE
Refactor SecureTemporaryFile using ChaCha20 in place of AES

### DIFF
--- a/backend/globaleaks/handlers/base.py
+++ b/backend/globaleaks/handlers/base.py
@@ -364,8 +364,6 @@ class BaseHandler(object):
             if self.request.args[b'flowChunkNumber'][0] != self.request.args[b'flowTotalChunks'][0]:
                 return None
 
-            f.finalize_write()
-
         mime_type, _ = mimetypes.guess_type(self.request.args[b'flowFilename'][0].decode())
         if mime_type is None:
             mime_type = 'application/octet-stream'

--- a/backend/globaleaks/handlers/recipient/export.py
+++ b/backend/globaleaks/handlers/recipient/export.py
@@ -221,7 +221,6 @@ class ExportHandler(BaseHandler):
         with stf.open('w') as f:
             for x in zipstream:
                 f.write(x)
-            f.finalize_write()
 
         with stf.open('r') as f:
             yield self.write_file_as_download(filename, f, pgp_key)

--- a/backend/globaleaks/tests/helpers.py
+++ b/backend/globaleaks/tests/helpers.py
@@ -436,7 +436,6 @@ def get_dummy_file(content=None):
 
     with temporary_file.open('w') as f:
         f.write(content)
-        f.finalize_write()
 
     State.TempUploadFiles[os.path.basename(temporary_file.filepath)] = temporary_file
 

--- a/backend/globaleaks/tests/utils/test_securetempfile.py
+++ b/backend/globaleaks/tests/utils/test_securetempfile.py
@@ -1,18 +1,53 @@
-# -*- coding: utf-8
-from globaleaks.settings import Settings
-from globaleaks.tests import helpers
+# -*- coding: utf-8 -*
+import os
+import shutil
+
+from tempfile import mkdtemp
+
+from twisted.trial import unittest
+
 from globaleaks.utils.securetempfile import SecureTemporaryFile
 
+TEST_DATA = b"Hello, world! This is a test data for writing, seeking and reading operations."
 
-class TestSecureTemporaryFiles(helpers.TestGL):
-    def test_temporary_file(self):
-        a = SecureTemporaryFile(Settings.tmp_path)
-        antani = "0123456789"
-        with a.open('w') as f:
-            for _ in range(1000):
-                f.write(antani)
-            f.finalize_write()
+class TestSecureTemporaryFiles(unittest.TestCase):
+    def setUp(self):
+        self.storage_dir = mkdtemp()
+        self.ephemeral_file = SecureTemporaryFile(self.storage_dir)
 
-        with a.open('r') as f:
-            for x in range(1000):
-                self.assertTrue(antani == f.read(10).decode())
+    def tearDown(self):
+        shutil.rmtree(self.storage_dir)
+
+    def test_create_and_write_file(self):
+        with self.ephemeral_file.open('w') as file:
+            for x in range(10):
+                self.assertEqual(self.ephemeral_file.size, x * len(TEST_DATA))
+                file.write(TEST_DATA)
+
+        self.assertTrue(os.path.exists(self.ephemeral_file.filepath))
+        self.assertEqual(self.ephemeral_file.size, len(TEST_DATA) * 10)
+
+    def test_encryption_and_decryption(self):
+        with self.ephemeral_file.open('w') as file:
+            file.write(TEST_DATA)
+
+        # Define test cases: each case is a tuple (seek_position, read_size, expected_data)
+        seek_tests = [
+            (0, 1, TEST_DATA[:1]),  # Seek at the start read 1 byte
+            (5, 5, TEST_DATA[5:10]),  # Seek forward, read 5 bytes
+            (10, 2, TEST_DATA[10:12]),  # Seek forward, read 2 bytes
+            (0, 3, TEST_DATA[:3]),  # Seek backward, read 3 bytes
+        ]
+
+        # Test forward and backward seeking with different offsets
+        with self.ephemeral_file.open('r') as file:
+            for seek_pos, read_size, expected in seek_tests:
+                file.seek(seek_pos)  # Seek to the given position
+                self.assertEqual(file.tell(), seek_pos)  # Check position after seeking forward
+                read_data = file.read(read_size)  # Read the specified number of bytes
+                self.assertEqual(read_data, expected)  # Verify the data matches the expected value
+
+    def test_file_cleanup(self):
+        path_copy = self.ephemeral_file.filepath
+        del self.ephemeral_file
+        self.assertFalse(os.path.exists(path_copy))

--- a/backend/globaleaks/tests/utils/test_securetempfile.py
+++ b/backend/globaleaks/tests/utils/test_securetempfile.py
@@ -27,25 +27,9 @@ class TestSecureTemporaryFiles(unittest.TestCase):
         self.assertTrue(os.path.exists(self.ephemeral_file.filepath))
         self.assertEqual(self.ephemeral_file.size, len(TEST_DATA) * 10)
 
-    def test_encryption_and_decryption(self):
-        with self.ephemeral_file.open('w') as file:
-            file.write(TEST_DATA)
-
-        # Define test cases: each case is a tuple (seek_position, read_size, expected_data)
-        seek_tests = [
-            (0, 1, TEST_DATA[:1]),  # Seek at the start read 1 byte
-            (5, 5, TEST_DATA[5:10]),  # Seek forward, read 5 bytes
-            (10, 2, TEST_DATA[10:12]),  # Seek forward, read 2 bytes
-            (0, 3, TEST_DATA[:3]),  # Seek backward, read 3 bytes
-        ]
-
-        # Test forward and backward seeking with different offsets
         with self.ephemeral_file.open('r') as file:
-            for seek_pos, read_size, expected in seek_tests:
-                file.seek(seek_pos)  # Seek to the given position
-                self.assertEqual(file.tell(), seek_pos)  # Check position after seeking forward
-                read_data = file.read(read_size)  # Read the specified number of bytes
-                self.assertEqual(read_data, expected)  # Verify the data matches the expected value
+            for _ in range(10):
+                self.assertEqual(file.read(len(TEST_DATA)), TEST_DATA)
 
     def test_file_cleanup(self):
         path_copy = self.ephemeral_file.filepath

--- a/backend/globaleaks/utils/securetempfile.py
+++ b/backend/globaleaks/utils/securetempfile.py
@@ -7,7 +7,7 @@ from cryptography.hazmat.primitives.ciphers.algorithms import ChaCha20
 CHUNK_SIZE = 4096
 
 class SecureTemporaryFile:
-    def __init__(self, filesdir, filename=None):
+    def __init__(self, filesdir):
         """
         Initializes an ephemeral file with ChaCha20 encryption.
         Creates a new random file path and generates a unique encryption key and nonce.
@@ -15,9 +15,9 @@ class SecureTemporaryFile:
         :param filesdir: The directory where the ephemeral file will be stored.
         :param filenames: Optional filename. If not provided, a UUID4 is used.
         """
-        filename = filename or str(uuid.uuid4())  # If filenames is None, generate a random UUID as a string
+        filename = str(uuid.uuid4())
         self.filepath = os.path.join(filesdir, filename)
-        self.cipher = Cipher(ChaCha20(os.urandom(32), uuid.UUID(filename).bytes[:16]), mode=None)
+        self.cipher = Cipher(ChaCha20(os.urandom(32), os.urandom(16)), mode=None)
         self.enc = self.cipher.encryptor()
         self.dec = self.cipher.decryptor()
 

--- a/backend/globaleaks/utils/securetempfile.py
+++ b/backend/globaleaks/utils/securetempfile.py
@@ -1,74 +1,134 @@
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8
 import os
+import uuid
+from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.primitives.ciphers.algorithms import ChaCha20
 
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+CHUNK_SIZE = 4096
 
-from globaleaks.utils.utility import uuid4
-
-crypto_backend = default_backend()
-
-
-class SecureTemporaryFile(object):
-    def __init__(self, filesdir):
+class SecureTemporaryFile:
+    def __init__(self, filesdir, filename=None):
         """
-        Create the AES Key to encrypt the uploaded file and initialize the cipher
+        Initializes an ephemeral file with ChaCha20 encryption.
+        Creates a new random file path and generates a unique encryption key and nonce.
+
+        :param filesdir: The directory where the ephemeral file will be stored.
+        :param filenames: Optional filename. If not provided, a UUID4 is used.
         """
-        self.fd = None
-        self.key = os.urandom(32)
-        self.key_id = uuid4()
-        self.key_counter_nonce = os.urandom(16)
-        self.cipher = Cipher(algorithms.AES(self.key), modes.CTR(self.key_counter_nonce), backend=crypto_backend)
-        self.filepath = os.path.join(filesdir, self.key_id)
-        self.size = 0
+        filename = filename or str(uuid.uuid4())  # If filenames is None, generate a random UUID as a string
+        self.filepath = os.path.join(filesdir, filename)
+        self.cipher = Cipher(ChaCha20(os.urandom(32), uuid.UUID(filename).bytes[:16]), mode=None)
         self.enc = self.cipher.encryptor()
-        self.dec = None
+        self.dec = self.cipher.decryptor()
 
-    def open(self, mode):
-        if mode == 'w':
-            self.fd = open(self.filepath, 'ab+')
-        else:
-            self.fd = open(self.filepath, 'rb')
-            self.dec = self.cipher.decryptor()
+        self.fd = None
 
+    @property
+    def size(self):
+        """
+        Returns the size of the encrypted file that is the same of the plaintext file
+        """
+        try:
+            return os.stat(self.filepath).st_size
+        except:
+            return 0
+
+    def open(self, flags, mode=0o660):
+        """
+        Opens the ephemeral file for reading or writing.
+
+        :param mode: 'w' for writing, 'r' for reading.
+        :return: The file object.
+        """
+        self.fd = os.open(self.filepath, os.O_RDWR | os.O_CREAT | os.O_APPEND, mode)
+        os.chmod(self.filepath, mode)
         return self
 
     def write(self, data):
-        if isinstance(data, str):
-            data = data.encode()
+        """
+        Writes encrypted data to the file.
 
-        self.fd.write(self.enc.update(data))
-        self.size += len(data)
+        :param data: Data to write to the file, can be a string or bytes.
+        """
+        os.write(self.fd, self.enc.update(data))
 
-    def finalize_write(self):
-        self.fd.write(self.enc.finalize())
+    def read(self, size=None):
+        """
+        Reads data from the current position in the file.
 
-    def read(self, c=None):
-        if c is None:
-            data = self.fd.read()
-        else:
-            data = self.fd.read(c)
+        :param size: The number of bytes to read. If None, reads until the end of the file.
+        :return: The decrypted data read from the file.
+        """
+        data = b""
+        bytes_read = 0
 
-        if data:
-            return self.dec.update(data)
+        while True:
+            # Determine how much to read in this chunk
+            chunk_size = min(CHUNK_SIZE, size - bytes_read) if size is not None else CHUNK_SIZE
 
-        return self.dec.finalize()
+            chunk = os.read(self.fd, chunk_size)
+            if not chunk:  # End of file
+                break
+
+            data += self.dec.update(chunk)
+            bytes_read += len(chunk)
+
+            if size is not None and bytes_read >= size:
+                break
+
+        return data
+
+    def seek(self, offset):
+        """
+        Sets the position for the next read operation.
+
+        :param offset: The offset to seek to.
+        """
+        position = 0
+        self.dec = self.cipher.decryptor()
+        self.enc = self.cipher.encryptor()
+        os.lseek(self.fd, 0, os.SEEK_SET)
+        discard_size = offset - position
+        while discard_size > 0:
+            to_read = min(CHUNK_SIZE, discard_size)
+            data = self.dec.update(os.read(self.fd, to_read))
+            data = self.enc.update(data)
+            discard_size -= to_read
+
+    def tell(self):
+        """
+        Returns the current position in the file.
+
+        :return: The current position in the file.
+        """
+        return os.lseek(self.fd, 0, os.SEEK_CUR)
 
     def close(self):
+        """
+        Closes the file descriptor.
+        """
         if self.fd is not None:
-            self.fd.close()
+            os.close(self.fd)
             self.fd = None
 
     def __enter__(self):
+        """
+        Allows the use of the file in a 'with' statement.
+        """
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Ensures the file is closed when exiting a 'with' statement.
+        """
         self.close()
 
     def __del__(self):
+        """
+        Ensures the file is cleaned up by closing it and removing the file.
+        """
         self.close()
-
         try:
-            os.remove(self.filepath)
-        except:
+            os.unlink(self.filepath)
+        except FileNotFoundError:
             pass

--- a/backend/globaleaks/utils/securetempfile.py
+++ b/backend/globaleaks/utils/securetempfile.py
@@ -78,31 +78,6 @@ class SecureTemporaryFile:
 
         return data
 
-    def seek(self, offset):
-        """
-        Sets the position for the next read operation.
-
-        :param offset: The offset to seek to.
-        """
-        position = 0
-        self.dec = self.cipher.decryptor()
-        self.enc = self.cipher.encryptor()
-        os.lseek(self.fd, 0, os.SEEK_SET)
-        discard_size = offset - position
-        while discard_size > 0:
-            to_read = min(CHUNK_SIZE, discard_size)
-            data = self.dec.update(os.read(self.fd, to_read))
-            data = self.enc.update(data)
-            discard_size -= to_read
-
-    def tell(self):
-        """
-        Returns the current position in the file.
-
-        :return: The current position in the file.
-        """
-        return os.lseek(self.fd, 0, os.SEEK_CUR)
-
     def close(self):
         """
         Closes the file descriptor.

--- a/documentation/security/ApplicationSecurity.rst
+++ b/documentation/security/ApplicationSecurity.rst
@@ -424,7 +424,7 @@ The default configuration has this feature disabled.
 
 Encryption of temporary files
 -----------------------------
-Files uploaded and temporarily stored on disk during the upload process are encrypted with a temporary, symmetric AES key to prevent any unencrypted data from being written to disk. Encryption is performed in streaming mode using `AES 128-bit` in `CTR mode`. Key files are stored in memory and are unique for each file being uploaded.
+Files uploaded and temporarily stored on disk during the upload process are encrypted with a ChaCha20 and temporary 256bit keys to prevent any unencrypted data from being written to disks. Key files are stored in memory and are unique for each file being uploaded.
 
 Secure file delete
 ------------------


### PR DESCRIPTION
With this pull request i would like to propose the refactoring of SecureTemporaryFile using ChaCha20 in place of AES

The change anticipates the possible integration of the [ephemeral-fs 
](https://github.com/globaleaks/globaleaks-whistleblowing-software/tree/feature/ephemeral-fs)