### PR TITLE
Fix grammer in brand guidelines section (issue #4429)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A big thank you to everyone who has already [contributed](https://github.com/glo
 
 ## Brand Guidelines and Brand Assets
 Within the GlobaLeaks project we researched a nice and smooth brand style, using accessible colors and trying to communicate our values.
-If you are planning some press releases, a conference, or promoting GlobaLeaks please keep at reference our official [Brand Guidelines](https://github.com/globaleaks/globaleaks-whistleblowing-software/blob/stable/brand/globaleaks-brand-guidelines.pdf) and use our [Brand Assets](https://github.com/globaleaks/globaleaks-whistleblowing-software/blob/stable/brand/assets/).
+If you are planning some press releases, a conference, or promoting GlobaLeaks please refer to our official [Brand Guidelines](https://github.com/globaleaks/globaleaks-whistleblowing-software/blob/stable/brand/globaleaks-brand-guidelines.pdf) and use our [Brand Assets](https://github.com/globaleaks/globaleaks-whistleblowing-software/blob/stable/brand/assets/).
 
 ## License
 GlobaLeaks is released under the [AGPLv3 license](https://github.com/globaleaks/globaleaks-whistleblowing-software/blob/stable/LICENSE) with [additional terms](https://github.com/globaleaks/globaleaks-whistleblowing-software/blob/stable/LICENSE#L679) allowed under section 7 of the AGPLv3. These terms are designed to make whistleblowers aware of the technology they are using and to enhance administrators' responsibility in keeping systems up-to-date.

--- a/client/app/assets/data_src/texts.txt
+++ b/client/app/assets/data_src/texts.txt
@@ -161,7 +161,7 @@ Fingerprint
 First
 Fiscal code
 Footer
-For security reasons the code needs to be changed.
+For security reasons, the code needs to be changed.
 For security reasons, password changes are required at regular intervals.
 For the user documentation, visit:
 Forbidden operation

--- a/client/app/src/shared/modals/otkc-access/otkc-access.component.html
+++ b/client/app/src/shared/modals/otkc-access/otkc-access.component.html
@@ -7,7 +7,7 @@
 <div class="modal-body">
     <div class="row">
         <div class="col-md-12">
-            <label for="ReceiptCode">{{ 'For security reasons, the code needs to be changed' | translate }}.</label>
+            <label for="ReceiptCode">{{ 'For security reasons, the code needs to be changed.' | translate }}.</label>
             <div class="mt-2 form-inline d-flex justify-content-center" ngbTooltip="{{'Copy to clipboard' | translate}}"
                 (click)="utils.copyToClipboard(arg.receipt)">
                 <div class="form-group d-block mx-auto">


### PR DESCRIPTION
This PR fixes a grammatical issue in the brand guidelines section of the README.md file.
Related to #4429.
