### PR TITLE
Fix for issue #4581

### DIFF
--- a/client/app/src/services/helper/locale-provider.ts
+++ b/client/app/src/services/helper/locale-provider.ts
@@ -75,6 +75,8 @@ import localeLo from '@angular/common/locales/lo';
 import localeLoExtra from '@angular/common/locales/extra/lo';
 import localeLt from '@angular/common/locales/lt';
 import localeLtExtra from '@angular/common/locales/extra/lt';
+import localeLv from '@angular/common/locales/lv';
+import localeLvExtra from '@angular/common/locales/extra/lv';
 import localeMg from '@angular/common/locales/mg';
 import localeMgExtra from '@angular/common/locales/extra/mg';
 import localeMk from '@angular/common/locales/mk';
@@ -145,6 +147,10 @@ import localeZhHk from '@angular/common/locales/zh-Hant-HK';
 import localeZhHkExtra from '@angular/common/locales/extra/zh-Hant-HK';
 import localeZhTw from '@angular/common/locales/zh-Hant';
 import localeZhTwExtra from '@angular/common/locales/extra/zh-Hant';
+import localeHy from '@angular/common/locales/hy';
+import localeHyExtra from '@angular/common/locales/extra/hy';
+import localeKl from '@angular/common/locales/kl';
+import localeKlExtra from '@angular/common/locales/extra/kl';
 
 // Registering all locales using your original codes
 export function registerLocales(): void {
@@ -185,6 +191,7 @@ export function registerLocales(): void {
   registerLocaleData(localeKy, 'ky', localeKyExtra);
   registerLocaleData(localeLo, 'lo', localeLoExtra);
   registerLocaleData(localeLt, 'lt', localeLtExtra);
+  registerLocaleData(localeLv, 'lv', localeLvExtra);
   registerLocaleData(localeMg, 'mg', localeMgExtra);
   registerLocaleData(localeMk, 'mk', localeMkExtra);
   registerLocaleData(localeMs, 'ms', localeMsExtra);
@@ -220,4 +227,6 @@ export function registerLocales(): void {
   registerLocaleData(localeZhCn, 'zh_CN', localeZhCnExtra); // Using 'zh_CN'
   registerLocaleData(localeZhHk, 'zh_HK', localeZhHkExtra); // Using 'zh_HK'
   registerLocaleData(localeZhTw, 'zh_TW', localeZhTwExtra); // Using 'zh_TW'
+  registerLocaleData(localeHy, 'hy', localeHyExtra);
+  registerLocaleData(localeKl, 'kl', localeKlExtra);
 }

--- a/client/app/src/shared/services/custom-datepicker-i18n.ts
+++ b/client/app/src/shared/services/custom-datepicker-i18n.ts
@@ -34,7 +34,7 @@ export class CustomDatepickerI18n extends NgbDatepickerI18n {
                                             // Ora e sempre resistenza!
     const targetDate = new Date(baseDate);
     targetDate.setDate(baseDate.getDate() + (weekday - 3));
-    return formatDate(targetDate, 'EEE', this.locale);
+    return formatDate(targetDate, 'EEEEE', this.locale);
   }
 
   // Full month name using Angular's formatDate

--- a/client/app/src/shared/services/custom-datepicker-i18n.ts
+++ b/client/app/src/shared/services/custom-datepicker-i18n.ts
@@ -15,7 +15,7 @@ export class CustomDatepickerI18n extends NgbDatepickerI18n {
     this.translationService.currentLocale$.subscribe(locale => {
       if (locale === 'crh') {
         this.locale = 'tk';
-      } else if (locale === 'dv') {
+      } else if (locale === 'ba' || locale === 'dv' || locale.startsWith('ug')) {
         this.locale = 'en';
       } else {
         this.locale = locale;
@@ -34,7 +34,7 @@ export class CustomDatepickerI18n extends NgbDatepickerI18n {
                                             // Ora e sempre resistenza!
     const targetDate = new Date(baseDate);
     targetDate.setDate(baseDate.getDate() + (weekday - 3));
-    return formatDate(targetDate, 'EEEEE', this.locale);
+    return formatDate(targetDate, 'EEEEEE', this.locale);
   }
 
   // Full month name using Angular's formatDate


### PR DESCRIPTION
In this pull request, I have addressed the issue https://github.com/globaleaks/globaleaks-whistleblowing-software/issues/4581 and implemented the following changes:

- Registered missing locales/languages from the locale-provider.ts helper file, fixing Angular error NG0701.
- Changed formatDate function in the custom-datepicker-i18n.ts file from the previous EEE to the EEEEE format, in order to display the short version for the week days, preventing the text overflow in several languages/locales with longer strings. This solution also prevents the need for visual/CSS changes.