### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ If you would like to implement a new feature, please consider the size of the ch
 
 ### <a name="submit-issue"></a> Opening a Ticket
 
-Before you open a ticket, please search through the [List of Tickets]((https://github.com/globaleaks/globaleaks-whistleblowing-software/issues)). A ticket for your problem might already exist and the discussion might inform you of workarounds readily available.
+Before you open a ticket, please search through the [List of Tickets](https://github.com/globaleaks/globaleaks-whistleblowing-software/issues). A ticket for your problem might already exist and the discussion might inform you of workarounds readily available.
 
 We want to fix all the issues as soon as possible, but before fixing a bug, we need to reproduce and confirm it.
 In order to reproduce bugs, we require that you provide a minimal reproduction.


### PR DESCRIPTION
### Problem
The 'List of Tickets' link in the CONTRIBUTING.md file used incorrect Markdown syntax
with double parentheses ((...)), causing the link to render incorrectly on GitHub.

### Solution
Replaced the double parentheses with valid Markdown link syntax so the link
displays and works correctly.

### Checklist
- [x] Description of the problem provided
- [x] Overview of the suggested solution
- [x] Proposed change is functional (Markdown renders correctly)
- [x] No tests required for this documentation fix
- [x] All existing tests remain unaffected
- [x] No reduction in code quality or test coverage
