### PR TITLE
Limit usage of data sources

### DIFF
--- a/backend/globaleaks/rest/api.py
+++ b/backend/globaleaks/rest/api.py
@@ -557,7 +557,7 @@ class APIResourceWrapper(Resource):
                               b"form-action 'none';"
                               b"frame-ancestors 'none';"
                               b"frame-src 'self';"
-                              b"img-src 'self' data:;"
+                              b"img-src 'self';"
                               b"media-src 'self';"
                               b"script-src 'self';"
                               b"style-src 'self' 'nonce-" + request.nonce + b"';"

--- a/backend/globaleaks/tests/rest/test_api.py
+++ b/backend/globaleaks/tests/rest/test_api.py
@@ -132,7 +132,7 @@ class TestAPI(TestGL):
                                                     'form-action \'none\';' \
                                                     'frame-ancestors \'none\';' \
                                                     'frame-src \'self\';' \
-                                                    'img-src \'self\' data:;' \
+                                                    'img-src \'self\';' \
                                                     'media-src \'self\';' \
                                                     'script-src \'self\';' \
                                                     'style-src \'self\' \'random-nonce\';' \

--- a/client/app/css/main.css
+++ b/client/app/css/main.css
@@ -1184,6 +1184,5 @@ body .dropdown-visible > div.multiselect-dropdown > div > span.dropdown-btn {
   background:
     linear-gradient(45deg, transparent 50%, #1d1f2a 50%) right 0.9em center / 8px 8px no-repeat,
     linear-gradient(-45deg, transparent 50%, #1d1f2a 50%) right 0.4em center / 8px 8px no-repeat;
-
   background-color: white;
 }

--- a/client/app/css/main.css
+++ b/client/app/css/main.css
@@ -1172,3 +1172,8 @@ body .dropdown-visible > div.multiselect-dropdown > div > span.dropdown-btn {
 .form-select {
   padding: 0.3em !important;
 }
+
+.modal-btn-close {
+  all: unset;
+  margin-left: auto;
+}

--- a/client/app/css/main.css
+++ b/client/app/css/main.css
@@ -1177,3 +1177,13 @@ body .dropdown-visible > div.multiselect-dropdown > div > span.dropdown-btn {
   all: unset;
   margin-left: auto;
 }
+
+.ngb-dp-navigation-select .form-select {
+  --bs-form-select-bg-img: none;
+
+  background:
+    linear-gradient(45deg, transparent 50%, #1d1f2a 50%) right 0.9em center / 8px 8px no-repeat,
+    linear-gradient(-45deg, transparent 50%, #1d1f2a 50%) right 0.4em center / 8px 8px no-repeat;
+
+  background-color: white;
+}

--- a/client/app/src/shared/modals/add-option-hint/add-option-hint.component.html
+++ b/client/app/src/shared/modals/add-option-hint/add-option-hint.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Hint' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <div>
@@ -14,15 +14,15 @@
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Confirm' | translate }}</span>
   </button>
   <button id="modal-action-reset" class="btn btn-danger" (click)="arg.hint1 = ''; arg.hint2 = '';cancel()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Reset' | translate }}</span>
   </button>
   <button id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'Cancel' | translate }}</span>
   </button>
 </div>

--- a/client/app/src/shared/modals/add-option-hint/add-option-hint.component.html
+++ b/client/app/src/shared/modals/add-option-hint/add-option-hint.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Hint' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <div>

--- a/client/app/src/shared/modals/assign-score-points/assign-score-points.component.html
+++ b/client/app/src/shared/modals/assign-score-points/assign-score-points.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Assign score points' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <span class="">

--- a/client/app/src/shared/modals/assign-score-points/assign-score-points.component.html
+++ b/client/app/src/shared/modals/assign-score-points/assign-score-points.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Assign score points' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <span class="">
@@ -21,15 +21,15 @@
   </div>
   <div class="modal-footer">
     <a id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-      <i class="fas fa-check"></i>
+      <i class="fas fa-check" aria-hidden="true"></i>
       <span>{{ 'Confirm' | translate }}</span>
     </a>
     <a id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-      <i class="fas fa-xmark"></i>
+      <i class="fas fa-xmark" aria-hidden="true"></i>
       <span>{{ 'Cancel' | translate }}</span>
     </a>
     <a id="modal-action-reset" class="btn btn-danger" (click)="arg.score_type = 'none'; arg.score_points = 0; cancel()">
-      <i class="fas fa-check"></i>
+      <i class="fas fa-check" aria-hidden="true"></i>
       <span>{{ 'Reset' | translate }}</span>
     </a>
   </div>

--- a/client/app/src/shared/modals/change-submission-status/change-submission-status.component.html
+++ b/client/app/src/shared/modals/change-submission-status/change-submission-status.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Change status' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <div>{{ 'Status:' | translate }}</div>

--- a/client/app/src/shared/modals/change-submission-status/change-submission-status.component.html
+++ b/client/app/src/shared/modals/change-submission-status/change-submission-status.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Change status' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <div>{{ 'Status:' | translate }}</div>
@@ -14,11 +14,11 @@
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm(arg.status)">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Confirm' | translate }}</span>
   </button>
   <span id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'Cancel' | translate }}</span>
   </span>
 </div>

--- a/client/app/src/shared/modals/confirmation/confirmation.component.html
+++ b/client/app/src/shared/modals/confirmation/confirmation.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Are you sure?' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body"></div>
 <div class="modal-footer">

--- a/client/app/src/shared/modals/confirmation/confirmation.component.html
+++ b/client/app/src/shared/modals/confirmation/confirmation.component.html
@@ -1,15 +1,15 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Are you sure?' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body"></div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm(arg)">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Yes' | translate }}</span>
   </button>
   <button id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'No' | translate }}</span>
   </button>
 </div>

--- a/client/app/src/shared/modals/delete-confirmation/delete-confirmation.component.html
+++ b/client/app/src/shared/modals/delete-confirmation/delete-confirmation.component.html
@@ -1,13 +1,13 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">{{'Please note that all the associated data will be permanently deleted.' | translate}}</div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i><span>{{'Yes' | translate}}</span>
+    <i class="fas fa-check" aria-hidden="true"></i><span>{{'Yes' | translate}}</span>
   </button>
   <button id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i><span>{{'No' | translate}}</span>
+    <i class="fas fa-xmark" aria-hidden="true"></i><span>{{'No' | translate}}</span>
   </button>
 </div>

--- a/client/app/src/shared/modals/delete-confirmation/delete-confirmation.component.html
+++ b/client/app/src/shared/modals/delete-confirmation/delete-confirmation.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">{{'Please note that all the associated data will be permanently deleted.' | translate}}</div>
 <div class="modal-footer">

--- a/client/app/src/shared/modals/disclaimer/disclaimer.component.html
+++ b/client/app/src/shared/modals/disclaimer/disclaimer.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header justify-content-end">
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <markdown class="disclaimer-text" [data]="appDataService.public.node.disclaimer_text | stripHtml"></markdown>

--- a/client/app/src/shared/modals/disclaimer/disclaimer.component.html
+++ b/client/app/src/shared/modals/disclaimer/disclaimer.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header justify-content-end">
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <markdown class="disclaimer-text" [data]="appDataService.public.node.disclaimer_text | stripHtml"></markdown>

--- a/client/app/src/shared/modals/enable-encryption/enable-encryption.component.html
+++ b/client/app/src/shared/modals/enable-encryption/enable-encryption.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <span>{{'Before proceeding please read carefully the documentation at:' | translate}}</span>
@@ -8,9 +8,9 @@
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i><span>{{'Yes' | translate}}</span>
+    <i class="fas fa-check" aria-hidden="true"></i><span>{{'Yes' | translate}}</span>
   </button>
   <button id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i><span>{{'No' | translate}}</span>
+    <i class="fas fa-xmark" aria-hidden="true"></i><span>{{'No' | translate}}</span>
   </button>
 </div>

--- a/client/app/src/shared/modals/enable-encryption/enable-encryption.component.html
+++ b/client/app/src/shared/modals/enable-encryption/enable-encryption.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <span>{{'Before proceeding please read carefully the documentation at:' | translate}}</span>

--- a/client/app/src/shared/modals/file-view/file-view.component.html
+++ b/client/app/src/shared/modals/file-view/file-view.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{args.file.name}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   @if (!args.loaded) {

--- a/client/app/src/shared/modals/file-view/file-view.component.html
+++ b/client/app/src/shared/modals/file-view/file-view.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{args.file.name}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   @if (!args.loaded) {

--- a/client/app/src/shared/modals/grant-access/grant-access.component.html
+++ b/client/app/src/shared/modals/grant-access/grant-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Grant access'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <div id="ReceiverContextAdder" class="form-group">

--- a/client/app/src/shared/modals/grant-access/grant-access.component.html
+++ b/client/app/src/shared/modals/grant-access/grant-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Grant access'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <div id="ReceiverContextAdder" class="form-group">
@@ -12,7 +12,7 @@
       </ng-select>
       <div class="input-group-append">
         <span class="input-group-text h-100">
-          <i class="fas fa-magnifying-glass"></i>
+          <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
         </span>
       </div>
     </div>
@@ -21,7 +21,7 @@
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">{{'Confirm' | translate}}</button>
   <a id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{'Close' | translate}}</span>
   </a>
 </div>

--- a/client/app/src/shared/modals/otkc-access/otkc-access.component.html
+++ b/client/app/src/shared/modals/otkc-access/otkc-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Attention' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <div class="row">
@@ -12,7 +12,7 @@
             <input id="ReceiptCode" class="form-control text-center" type="text" maxlength="19" size="19" [(ngModel)]="arg.formatted_receipt" name="receipt-input">
             <span class="input-group-append">
               <button id="ReceiptButton" (click)="utils.copyToClipboard(arg.receipt)" class="btn btn-primary rounded-start-0" type="button" [attr.aria-label]="'Copy to clipboard' | translate">
-                <i class="fas fa-copy"></i>
+                <i class="fas fa-copy" aria-hidden="true"></i>
               </button>
             </span>
           </div>
@@ -24,7 +24,7 @@
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">{{ 'Confirm' | translate }}</button>
   <a id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'Close' | translate }}</span>
   </a>
 </div>

--- a/client/app/src/shared/modals/otkc-access/otkc-access.component.html
+++ b/client/app/src/shared/modals/otkc-access/otkc-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Attention' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <div class="row">

--- a/client/app/src/shared/modals/questionnaire-duplication/questionnaire-duplication.component.html
+++ b/client/app/src/shared/modals/questionnaire-duplication/questionnaire-duplication.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Enter a name for the copy' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <span>{{ 'Name' | translate }}</span>

--- a/client/app/src/shared/modals/questionnaire-duplication/questionnaire-duplication.component.html
+++ b/client/app/src/shared/modals/questionnaire-duplication/questionnaire-duplication.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Enter a name for the copy' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <span>{{ 'Name' | translate }}</span>
@@ -10,11 +10,11 @@
 </div>
 <div class="modal-footer">
   <span id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Duplicate' | translate }}</span>
   </span>
   <span id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'Cancel' | translate }}</span>
   </span>
 </div>

--- a/client/app/src/shared/modals/redact-information/redact-information.component.html
+++ b/client/app/src/shared/modals/redact-information/redact-information.component.html
@@ -5,7 +5,7 @@
   @if (!vars.redaction_switch) {
     <h5 class="modal-title">{{ 'Redact' | translate }}</h5>
   }
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 
 <div class="modal-body">

--- a/client/app/src/shared/modals/redact-information/redact-information.component.html
+++ b/client/app/src/shared/modals/redact-information/redact-information.component.html
@@ -5,7 +5,7 @@
   @if (!vars.redaction_switch) {
     <h5 class="modal-title">{{ 'Redact' | translate }}</h5>
   }
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 
 <div class="modal-body">
@@ -33,12 +33,12 @@
     </div>
 
     <div class="float-end">
-      <button id="toggle-button" (click)="toggleVisibility()" class="btn">
+      <button id="toggle-button" (click)="toggleVisibility()" class="btn" [attr.aria-label]="forced_visible ? ('Hide content' | translate) : ('Show content' | translate)">
         @if (forced_visible) {
-          <span id="eye-icon-open"><i class="fas fa-eye"></i></span>
+          <span id="eye-icon-open"><i class="fas fa-eye" aria-hidden="true"></i></span>
         }
         @if (!forced_visible) {
-          <span id="eye-icon-closed"><i class="fas fa-eye-slash"></i></span>
+          <span id="eye-icon-closed"><i class="fas fa-eye-slash" aria-hidden="true"></i></span>
         }
       </button>
 

--- a/client/app/src/shared/modals/reopen-submission/reopen-submission.component.html
+++ b/client/app/src/shared/modals/reopen-submission/reopen-submission.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Reopen' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body"></div>
 <div class="modal-footer">

--- a/client/app/src/shared/modals/reopen-submission/reopen-submission.component.html
+++ b/client/app/src/shared/modals/reopen-submission/reopen-submission.component.html
@@ -1,15 +1,15 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Reopen' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body"></div>
 <div class="modal-footer">
   <button type="button" id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Confirm' | translate }}</span>
   </button>
   <span id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'Cancel' | translate }}</span>
   </span>
 </div>

--- a/client/app/src/shared/modals/revoke-access/revoke-access.component.html
+++ b/client/app/src/shared/modals/revoke-access/revoke-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Revoke access' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <div id="ReceiverContextAdder" class="form-group">

--- a/client/app/src/shared/modals/revoke-access/revoke-access.component.html
+++ b/client/app/src/shared/modals/revoke-access/revoke-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Revoke access' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <div id="ReceiverContextAdder" class="form-group">
@@ -9,7 +9,7 @@
         <ng-template ng-label-tmp let-item="item">{{ item.name }}</ng-template>
       </ng-select>
       <div class="input-group-append">
-        <span class="input-group-text h-100"><i class="fas fa-magnifying-glass"></i></span>
+        <span class="input-group-text h-100"><i class="fas fa-magnifying-glass" aria-hidden="true"></i></span>
       </div>
     </div>
   </div>
@@ -17,7 +17,7 @@
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">{{'Confirm' | translate}}</button>
   <a id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{'Close' | translate}}</span>
   </a>
 </div>

--- a/client/app/src/shared/modals/tip-operation-file-identity-access-reply/tip-operation-file-identity-access-reply.component.html
+++ b/client/app/src/shared/modals/tip-operation-file-identity-access-reply/tip-operation-file-identity-access-reply.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Deny access to the whistleblower\'s identity'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <label>{{'Motivation'}}</label>
@@ -9,11 +9,11 @@
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" [disabled]="!reply_motivation" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{'Send'|translate}}</span>
   </button>
   <span id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{'Cancel'|translate}}</span>
   </span>
 </div>

--- a/client/app/src/shared/modals/tip-operation-file-identity-access-reply/tip-operation-file-identity-access-reply.component.html
+++ b/client/app/src/shared/modals/tip-operation-file-identity-access-reply/tip-operation-file-identity-access-reply.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Deny access to the whistleblower\'s identity'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <label>{{'Motivation'}}</label>

--- a/client/app/src/shared/modals/tip-operation-file-identity-access-request/tip-operation-file-identity-access-request.component.html
+++ b/client/app/src/shared/modals/tip-operation-file-identity-access-request/tip-operation-file-identity-access-request.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Request access to the whistleblower\'s identity' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <label>{{ 'Motivation' | translate }}</label>
@@ -9,11 +9,11 @@
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" [disabled]="!request_motivation" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Send' | translate }}</span>
   </button>
   <span id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'Cancel' | translate }}</span>
   </span>
 </div>

--- a/client/app/src/shared/modals/tip-operation-file-identity-access-request/tip-operation-file-identity-access-request.component.html
+++ b/client/app/src/shared/modals/tip-operation-file-identity-access-request/tip-operation-file-identity-access-request.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Request access to the whistleblower\'s identity' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <label>{{ 'Motivation' | translate }}</label>

--- a/client/app/src/shared/modals/tip-operation-postpone/tip-operation-postpone.component.html
+++ b/client/app/src/shared/modals/tip-operation-postpone/tip-operation-postpone.component.html
@@ -1,23 +1,23 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <span>{{'By confirming, you will edit the expiration date to:'|translate}}</span>
   <div class="input-group">
     <input type="text" readonly class="form-control" placeholder="yyyy-mm-dd" name="dp" [required]="true" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="args.expiration_date" ngbDatepicker #d="ngbDatepicker" (click)="d.toggle()" />
-    <button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button">
-      <i class="fas fa-calendar"></i>
+    <button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button" [attr.aria-label]="'Open calendar' | translate">
+      <i class="fas fa-calendar" aria-hidden="true"></i>
     </button>
   </div>
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{'Yes'|translate}}</span>
   </button>
   <button id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{'No'|translate}}</span>
   </button>
 </div>

--- a/client/app/src/shared/modals/tip-operation-postpone/tip-operation-postpone.component.html
+++ b/client/app/src/shared/modals/tip-operation-postpone/tip-operation-postpone.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <span>{{'By confirming, you will edit the expiration date to:'|translate}}</span>

--- a/client/app/src/shared/modals/tip-operation-set-reminder/tip-operation-set-reminder.component.html
+++ b/client/app/src/shared/modals/tip-operation-set-reminder/tip-operation-set-reminder.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <span>{{'By confirming, you will set a reminder on date:' | translate}}</span>

--- a/client/app/src/shared/modals/tip-operation-set-reminder/tip-operation-set-reminder.component.html
+++ b/client/app/src/shared/modals/tip-operation-set-reminder/tip-operation-set-reminder.component.html
@@ -1,23 +1,23 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Are you sure?' | translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <span>{{'By confirming, you will set a reminder on date:' | translate}}</span>
   <div class="input-group">
     <input class="form-control" placeholder="yyyy-mm-dd" name="dp" [required]="true" (click)="d.toggle()" [(ngModel)]="args.reminder_date" ngbDatepicker #d="ngbDatepicker" />
-    <button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button">
-      <i class="fas fa-calendar"></i>
+    <button class="btn btn-outline-secondary bi bi-calendar3" (click)="d.toggle()" type="button" [attr.aria-label]="'Open calendar' | translate">
+      <i class="fas fa-calendar" aria-hidden="true"></i>
     </button>
   </div>
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{'Confirm' | translate}}</span>
   </button>
   <button id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{'Cancel' | translate}}</span>
   </button>
   <button id="modal-action-disable" class="btn btn-danger" (click)="disableReminder()">

--- a/client/app/src/shared/modals/transfer-access/transfer-access.component.html
+++ b/client/app/src/shared/modals/transfer-access/transfer-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Transfer access'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <div id="ReceiverContextAdder" class="form-group">

--- a/client/app/src/shared/modals/transfer-access/transfer-access.component.html
+++ b/client/app/src/shared/modals/transfer-access/transfer-access.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{'Transfer access'|translate}}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <div id="ReceiverContextAdder" class="form-group">
@@ -9,7 +9,7 @@
         <ng-template ng-label-tmp let-item="item">{{ item.name }}</ng-template>
       </ng-select>
       <div class="input-group-append">
-        <span class="input-group-text h-100"><i class="fas fa-magnifying-glass"></i></span>
+        <span class="input-group-text h-100"><i class="fas fa-magnifying-glass" aria-hidden="true"></i></span>
       </div>
     </div>
   </div>
@@ -19,7 +19,7 @@
     <span>{{'Confirm'|translate}}</span>
   </button>
   <a id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{'Close'|translate}}</span>
   </a>
 </div>

--- a/client/app/src/shared/modals/trigger-receiver/trigger-receiver.component.html
+++ b/client/app/src/shared/modals/trigger-receiver/trigger-receiver.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Recipients' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
 </div>
 <div class="modal-body">
   <div>{{ 'Recipients' | translate }}</div>

--- a/client/app/src/shared/modals/trigger-receiver/trigger-receiver.component.html
+++ b/client/app/src/shared/modals/trigger-receiver/trigger-receiver.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header">
   <h5 class="modal-title">{{ 'Recipients' | translate }}</h5>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark"></i></button>
+  <button type="button" class="btn-close" (click)="cancel()" [attr.aria-label]="'Close' | translate"><i class="fa-solid fa-circle-xmark" aria-hidden="true"></i></button>
 </div>
 <div class="modal-body">
   <div>{{ 'Recipients' | translate }}</div>
@@ -14,8 +14,8 @@
         @for (user of arg.trigger_receiver; track user; let i = $index) {
           <li>
             <span class="action-btns">
-              <span (click)="removeReceiver(i)" ngbTooltip="{{'Remove' | translate}}">
-                <i class="fas fa-xmark"></i>
+              <span (click)="removeReceiver(i)" ngbTooltip="{{'Remove' | translate}}" role="button" tabindex="0" [attr.aria-label]="'Remove' | translate">
+                <i class="fas fa-xmark" aria-hidden="true"></i>
               </span>
             </span>
             <span>{{ (admin_receivers_by_id[user] || {}).name || "-" }}</span>
@@ -27,15 +27,15 @@
 </div>
 <div class="modal-footer">
   <button id="modal-action-ok" class="btn btn-primary" (click)="confirm()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Confirm' | translate }}</span>
   </button>
   <button id="modal-action-reset" class="btn btn-danger" (click)="resetRecipients()">
-    <i class="fas fa-check"></i>
+    <i class="fas fa-check" aria-hidden="true"></i>
     <span>{{ 'Reset' | translate }}</span>
   </button>
   <button id="modal-action-cancel" class="btn btn-outline-secondary" (click)="cancel()">
-    <i class="fas fa-xmark"></i>
+    <i class="fas fa-xmark" aria-hidden="true"></i>
     <span>{{ 'Cancel' | translate }}</span>
   </button>
 </div>

--- a/documentation/technical/security/application-security.rst
+++ b/documentation/technical/security/application-security.rst
@@ -134,7 +134,7 @@ Content-Security-Policy
 The backend implements a strict `Content Security Policy (CSP) <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>`_ preventing any interaction with third-party resources and restricting execution of code by means of `Trusted Types <https://www.w3.org/TR/trusted-types/>`_.
 ::
 
-  Content-Security-Policy: base-uri 'none'; connect-src 'self'; default-src 'none'; font-src 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'self'; img-src 'self' data:; media-src 'self'; script-src 'self'; style-src 'self'; trusted-types angular angular#bundler default dompurify; require-trusted-types-for 'script'; report-to csp-endpoint;
+  Content-Security-Policy: base-uri 'none'; connect-src 'self'; default-src 'none'; font-src 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'self'; img-src 'self' media-src 'self'; script-src 'self'; style-src 'self'; trusted-types angular angular#bundler default dompurify; require-trusted-types-for 'script'; report-to csp-endpoint;
   Reporting-Endpoints: csp-endpoint="/api/report"
 
 Specific policies are implemented in adherence to the principle of least privilege.


### PR DESCRIPTION
This pull request:
- limits usage data sources for img-src by applying a set of fix on the usage of ng-boostrap
- limits usage of data sources for img-src restricting the content security policy
- updates the tests on the implemented content-security
- updates the documentation about the implemented content-security-policy