### PR TITLE
Fix gl-admin restore command failing with missing directory error

### DIFF
--- a/backend/bin/gl-admin
+++ b/backend/bin/gl-admin
@@ -125,11 +125,12 @@ def restore(args):
     p_head, p_tail = os.path.split(args.workdir)
 
     shutil.rmtree(args.workdir)
+    os.makedirs(args.workdir)
 
     print("Extracting the archive {}".format(args.backuppath))
     sp.check_call(["tar", "-xf", args.backuppath, "-C", args.workdir])
 
-    if must_stop: sp.check_call(["service", "globaleaks", "stop"])
+    if must_stop: sp.check_call(["service", "globaleaks", "start"])
 
     print("Success! globaleaks has been restored from a backup")
 

--- a/backend/globaleaks/tests/test_gl_admin.py
+++ b/backend/globaleaks/tests/test_gl_admin.py
@@ -1,0 +1,125 @@
+"""
+Tests for gl-admin backup and restore functionality.
+
+These tests verify that the backup/restore logic correctly handles
+directory recreation after shutil.rmtree().
+"""
+import os
+import shutil
+import tarfile
+import tempfile
+
+from twisted.trial import unittest
+
+
+class TestGLAdminBackupRestore(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.backup_file = os.path.join(tempfile.gettempdir(), 'test_backup.tar.gz')
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+        if os.path.exists(self.backup_file):
+            os.remove(self.backup_file)
+
+    def _create_test_directory_structure(self):
+        """Create a directory structure similar to /var/globaleaks"""
+        os.makedirs(os.path.join(self.test_dir, 'files'), exist_ok=True)
+        os.makedirs(os.path.join(self.test_dir, 'attachments'), exist_ok=True)
+        os.makedirs(os.path.join(self.test_dir, 'log'), exist_ok=True)
+        os.makedirs(os.path.join(self.test_dir, 'tmp'), exist_ok=True)
+
+        # Create test files
+        with open(os.path.join(self.test_dir, 'globaleaks.db'), 'w') as f:
+            f.write('test database content')
+
+        with open(os.path.join(self.test_dir, 'files', 'file1.txt'), 'w') as f:
+            f.write('test file content')
+
+        with open(os.path.join(self.test_dir, 'attachments', 'attach1.bin'), 'w') as f:
+            f.write('test attachment content')
+
+    def _perform_backup(self, workdir, backuppath):
+        """Simulate gl-admin backup logic using tarfile"""
+        with tarfile.open(backuppath, "w:gz") as tar:
+            for item in os.listdir(workdir):
+                if item != 'backups':
+                    tar.add(os.path.join(workdir, item), arcname=item)
+
+    def _perform_restore(self, workdir, backuppath):
+        """Simulate gl-admin restore logic (fixed version with os.makedirs)"""
+        shutil.rmtree(workdir)
+        os.makedirs(workdir)
+
+        with tarfile.open(backuppath, "r:gz") as tar:
+            tar.extractall(path=workdir, filter='data')
+
+    def test_rmtree_removes_directory(self):
+        """Test that shutil.rmtree removes the entire directory including root"""
+        self._create_test_directory_structure()
+
+        # Verify directory exists before rmtree
+        self.assertTrue(os.path.isdir(self.test_dir))
+
+        shutil.rmtree(self.test_dir)
+
+        # Verify directory no longer exists after rmtree
+        self.assertFalse(os.path.exists(self.test_dir))
+
+    def test_makedirs_recreates_directory(self):
+        """Test that os.makedirs recreates the directory after rmtree"""
+        self._create_test_directory_structure()
+
+        shutil.rmtree(self.test_dir)
+        self.assertFalse(os.path.exists(self.test_dir))
+
+        os.makedirs(self.test_dir)
+        self.assertTrue(os.path.isdir(self.test_dir))
+
+    def test_restore_succeeds_with_makedirs(self):
+        """Test that restore succeeds when directory is recreated after rmtree"""
+        self._create_test_directory_structure()
+        self._perform_backup(self.test_dir, self.backup_file)
+
+        self._perform_restore(self.test_dir, self.backup_file)
+
+        # Verify directory exists
+        self.assertTrue(os.path.isdir(self.test_dir))
+
+        # Verify files were restored
+        self.assertTrue(os.path.isfile(os.path.join(self.test_dir, 'globaleaks.db')))
+        self.assertTrue(os.path.isfile(os.path.join(self.test_dir, 'files', 'file1.txt')))
+        self.assertTrue(os.path.isfile(os.path.join(self.test_dir, 'attachments', 'attach1.bin')))
+
+    def test_restore_preserves_file_content(self):
+        """Test that restore preserves the original file content"""
+        self._create_test_directory_structure()
+
+        # Store original content
+        original_db_content = 'test database content'
+        original_file_content = 'test file content'
+
+        self._perform_backup(self.test_dir, self.backup_file)
+        self._perform_restore(self.test_dir, self.backup_file)
+
+        # Verify content
+        with open(os.path.join(self.test_dir, 'globaleaks.db'), 'r') as f:
+            self.assertEqual(f.read(), original_db_content)
+
+        with open(os.path.join(self.test_dir, 'files', 'file1.txt'), 'r') as f:
+            self.assertEqual(f.read(), original_file_content)
+
+    def test_restore_preserves_directory_structure(self):
+        """Test that restore preserves the original directory structure"""
+        self._create_test_directory_structure()
+        self._perform_backup(self.test_dir, self.backup_file)
+        self._perform_restore(self.test_dir, self.backup_file)
+
+        # Verify directory structure
+        self.assertTrue(os.path.isdir(os.path.join(self.test_dir, 'files')))
+        self.assertTrue(os.path.isdir(os.path.join(self.test_dir, 'attachments')))
+        self.assertTrue(os.path.isdir(os.path.join(self.test_dir, 'log')))
+        self.assertTrue(os.path.isdir(os.path.join(self.test_dir, 'tmp')))
+


### PR DESCRIPTION
Before submitting a pull request, please ensure the following:

- [x] The pull request includes a description of the problem you're trying to solve.
- [x] The pull request provides an overview of the suggested solution.
- [x] The proposed code is fully functional.
- [x] The proposed code includes relevant tests to verify its functionality.
- [x] All new and existing tests pass successfully.
- [x] Overall code quality and test coverage metrics are not reduced by more than 0.5%

Fixes #4739

### Problem

The `gl-admin restore` command fails with:
```bash
tar: /var/globaleaks: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

This was introduced in commit https://github.com/globaleaks/globaleaks-whistleblowing-software/commit/e1d12a3a10e34d25f274f03c70eea2fd17dcb585 when `shell=True` was removed from subprocess calls.

 The original `find -type f -exec shred` only deleted files while preserving directories, but `shutil.rmtree()` deletes the entire directory tree including the root.  

Since `tar -C` requires the target directory to exist, the restore fails.

### Solution

1. Add `os.makedirs(args.workdir)` after `shutil.rmtree(args.workdir)` to recreate the directory before extraction
2. Fix the service command from `stop` to `start` to correctly restart the service after restore (also introduced in the same commit)


### Tests Added

Added backend/globaleaks/tests/test_gl_admin.py with 5 test cases:

- `test_rmtree_removes_directory` - Verifies that shutil.rmtree() removes the entire directory including root
- `test_makedirs_recreates_directory` - Verifies that os.makedirs() recreates the directory after rmtree
- `test_restore_succeeds_with_makedirs` - Verifies the complete restore flow works with the fix
- `test_restore_preserves_file_content` - Verifies file content is preserved during restore
- `test_restore_preserves_directory_structure` - Verifies directory structure is preserved during restore
