### PR TITLE
Fix/docker amd64 platform

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@
 ARG BASE_IMAGE=debian:trixie-slim@sha256:38af8d51386e2fc12cc71c038c6343205450691f739fc5840dad7380a31e382e
 ARG DISTRIBUTION=trixie
 
-FROM ${BASE_IMAGE}
+FROM --platform=linux/amd64 ${BASE_IMAGE}
 
 ADD https://deb.globaleaks.org/install.sh /tmp/install.sh
 

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -3,6 +3,8 @@
 To run GlobaLeaks using Docker
 ```bash
  docker run -d --name globaleaks \
-  -p 80:80 -p 443:443 \
+  --platform linux/amd64 \
+  -p 80:8080 \
+  -p 443:8443 \
   -v globaleaks-data:/var/globaleaks \
   globaleaks/globaleaks:latest

--- a/docker/generate_docker_compose.sh
+++ b/docker/generate_docker_compose.sh
@@ -44,7 +44,11 @@ services:
   globaleaks:
     environment:
       DISTRIBUTION: ${name}
-    build: .
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ${base_image}
+        DISTRIBUTION: ${name}
     restart: unless-stopped
     container_name: globaleaks
     network_mode: bridge


### PR DESCRIPTION
## Problem

The Docker image published on Docker Hub resolves to **i386** when no platform is explicitly specified during build. This means that on a 64-bit host, the container userspace still runs **32-bit Python**, where `time_t` is a signed 32-bit integer.

The default timestamp `32503680000` (~year 3000) used in `get_receivertips()` overflows this limit, causing:

```
OverflowError on /api/recipient/rtips
```

This breaks **all recipient logins** for users running the official Docker image.

---

## Root causes (two separate bugs)

### 1. Missing `--platform` in Dockerfile
The `FROM` instruction had no `--platform` directive, leaving Docker free to resolve the base image to the host's default variant — which in some environments (e.g. multi-arch manifests) resolves to `i386`.

### 2. `generate_docker_compose.sh` was not passing build args
The generated `docker-compose.yml` used `build: .` (shorthand), which means **neither `BASE_IMAGE` nor `DISTRIBUTION` were passed as build-time arguments**. As a result:
- The Dockerfile always used its hardcoded `ARG` defaults, silently ignoring the distro selected at runtime.
- The `DISTRIBUTION` variable was only injected as a runtime environment variable, not as a build arg where the Dockerfile actually needs it.

---

## Changes

### `docker/Dockerfile`
Added `--platform=linux/amd64` to the `FROM` instruction to explicitly target the correct architecture:

```dockerfile
FROM --platform=linux/amd64 ${BASE_IMAGE}
```

### `docker/generate_docker_compose.sh`
Replaced the `build: .` shorthand with the full `build:` syntax, passing both `BASE_IMAGE` and `DISTRIBUTION` as proper build arguments:

```shell
    build:
      context: .
      args:
        BASE_IMAGE: ${base_image}
        DISTRIBUTION: ${name}
```

---

## Note for maintainers

If the CI pipeline that **publishes to Docker Hub** uses `docker buildx` or `docker/build-push-action`, it should also explicitly set:

```yaml
platforms: linux/amd64,linux/arm64
```

to ensure the published manifest is correct for all supported architectures. This is outside the scope of this PR as it requires access to Docker Hub secrets, but it is the complementary fix needed on the CI side.

---

Fixes #4751