### PR TITLE
Security: Path traversal risk when loading profile by name

### DIFF
--- a/backend/globaleaks/models/profiles.py
+++ b/backend/globaleaks/models/profiles.py
@@ -13,7 +13,15 @@ def load_profile(session, tid, name):
     :param tid: The tenant id of the tenant to be configured
     :param name: The name of the profile to be used
     """
-    path = os.path.join(Settings.client_path, 'data/profiles', '{}.json'.format(name))
+    if not name or not all(c.isalnum() or c in ('_', '-') for c in name):
+        raise ValueError('Invalid profile name')
+
+    profiles_dir = os.path.abspath(os.path.join(Settings.client_path, 'data/profiles'))
+    path = os.path.abspath(os.path.join(profiles_dir, '{}.json'.format(name)))
+
+    if os.path.commonpath([profiles_dir, path]) != profiles_dir:
+        raise ValueError('Invalid profile name')
+
     prof = read_json_file(path)
 
     ConfigFactory(session, tid).update('node', prof['node'])


### PR DESCRIPTION
## Problem

Profile path is built from `name` and directly joined into a filesystem path (`.../data/profiles/{name}.json`) without validation. If `name` is attacker-controlled in any call path, `../` sequences can escape the profiles directory and read unintended files.

**Severity**: `high`
**File**: `backend/globaleaks/models/profiles.py`

## Solution

Validate `name` against a strict allowlist (e.g., `^[a-zA-Z0-9_-]+$`), resolve with `os.path.abspath`, and enforce that the final path remains under the profiles directory before reading.

## Changes

- `backend/globaleaks/models/profiles.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
