### PR TITLE
Fix development environment guide and documentation typos

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -1,7 +1,7 @@
 Documentation
 =============
 
-.. note:: This documentation is thank to the support of our community. Join us and contribute with your additions and suggestion. In any of the page you find a link that enables you to provide suggestions and corrections. We remind you that in case of any software issue or bug you may always report on the `ticketing system <https://github.com/globaleaks/globaleaks-whistleblowing-software/issues>`_.
+.. note:: This documentation is thanks to the support of our community. Join us and contribute with your additions and suggestion. In any of the page you find a link that enables you to provide suggestions and corrections. We remind you that in case of any software issue or bug you may always report on the `ticketing system <https://github.com/globaleaks/globaleaks-whistleblowing-software/issues>`_.
 
 .. toctree::
   getting-started/index.rst

--- a/documentation/setup/update.rst
+++ b/documentation/setup/update.rst
@@ -16,9 +16,9 @@ Distribution upgrade
 --------------------
 For security and stability reasons it is recommended to not perform an automatic distribution upgrade.
 
-GlobaLeaks could be instead easily migrated migrated to a new up-to-date Debian system with the following recommended instructions:
+GlobaLeaks could be instead easily migrated to a new up-to-date Debian system with the following recommended instructions:
 
 - create an archive backup of /var/globaleaks
-- instantiate the lates Debian available
+- instantiate the latest Debian available
 - log on the new server and extract the backup in /var/globaleaks
 - follow the :doc:`Installation Guide </setup/installation>`; GlobaLeaks while installing will recognize the presence of an existing data directory and will use it

--- a/documentation/technical/development/continuous-integration.rst
+++ b/documentation/technical/development/continuous-integration.rst
@@ -5,7 +5,7 @@ The GlobaLeaks codebase is continuously tested for bug within a complete continu
 
 Testes are performed at every commit by:
 
-* performing continous integration testing with `GitHub Actions <https://github.com/globaleaks/globaleaks-whistleblowing-software/actions>`_;
+* performing continuous integration testing with `GitHub Actions <https://github.com/globaleaks/globaleaks-whistleblowing-software/actions>`_;
 * tracking tests coverage and code quality with `Codacy <https://app.codacy.com/manual/GlobaLeaks/GlobaLeaks>`_.
 
 Unit tests

--- a/documentation/technical/development/environment.rst
+++ b/documentation/technical/development/environment.rst
@@ -35,32 +35,31 @@ Client dependencies could be installed by issuing:
 
 .. code:: sh
 
-  cd GlobaLeaks/client
-  npm install -d
-  grunt copy:sources
+  cd globaleaks-whistleblowing-software/client
+  npm install -d 
 
 Backend dependencies could be installed by issuing:
 
 .. code:: sh
 
-  cd GlobaLeaks/backend
+  cd globaleaks-whistleblowing-software/backend
   python3 -m venv env
   source env/bin/activate
   pip3 install -r requirements.txt
 
-This will create for you a python virtualenv in the directory env containing all the required python dependencies. To leave the virtualenv, type ``deactivate``.
+This will create a Python virtualenv in the ``env`` directory containing all required dependencies. To leave the virtualenv, type ``deactivate``.
 
-Then, anytime you will want to activate the environment to run globaleaks you will just need to issue the command:
+Then, anytime you will want to activate the environment to run GlobaLeaks you will just need to issue the command:
 
 .. code:: sh
 
-  cd GlobaLeaks/backend && source ./env/bin/activate
+  cd globaleaks-whistleblowing-software/backend && source ./env/bin/activate
 
 Setup the client:
 
 .. code:: sh
 
-  cd GlobaLeaks/client
+  cd globaleaks-whistleblowing-software/client
   npm install -d
   grunt build
 
@@ -68,18 +67,18 @@ Setup the backend and its dependencies:
 
 .. code:: sh
 
-  cd GlobaLeaks/backend
+  cd globaleaks-whistleblowing-software/backend
   python3 -m venv env
   source env/bin/activate
   pip3 install -r requirements.txt
 
 Run
 ===
-To run globaleaks from sources within the development environment you should issue:
+To run GlobaLeaks from sources within the development environment you should issue:
 
 .. code:: sh
 
-  cd GlobaLeaks/backend
+  cd globaleaks-whistleblowing-software/backend
   source env/bin/activate
   bin/globaleaks -z -n
 
@@ -91,7 +90,7 @@ To build the documentation:
 
 .. code:: sh
 
-  cd GlobaLeaks/documentation
+  cd globaleaks-whistleblowing-software/documentation
   pip install -r requirements.txt
   make html
 
@@ -99,7 +98,7 @@ To edit the docs with hot-reload functionality:
 
 .. code:: sh
 
-  cd GlobaLeaks/documentation
+  cd globaleaks-whistleblowing-software/documentation
   python3 -m venv env
   source env/bin/activate
   pip install -r requirements.txt

--- a/documentation/technical/development/release-procedure.rst
+++ b/documentation/technical/development/release-procedure.rst
@@ -21,7 +21,7 @@ A new release version is issued by means of the official version bump script by 
 
 Release tagging
 ===============
-The release is tagged by meand of the following commands
+The release is tagged by means of the following commands
 
 .. code:: sh
 

--- a/documentation/technical/security/application-security.rst
+++ b/documentation/technical/security/application-security.rst
@@ -12,7 +12,7 @@ The software comprises two main components: a `Backend` and a `Client`:
 * The Backend is a Python-based server that runs on a physical server and exposes a `REST API <https://en.wikipedia.org/wiki/Representational_state_transfer>`_.
 * The Client is a TypeScript client-side web application that interacts with the Backend only through `XHR <https://en.wikipedia.org/wiki/XMLHttpRequest>`_.
 
-Following the `Zero Trust paradigm <https://nvlpubs.nist.gov/nistpubs/specialpublications/NIST.SP.800-207.pdf>`_ and aiming at implementing a fully auditable technlogy both the Backend and the Client are implemented using only open-source libraries.
+Following the `Zero Trust paradigm <https://nvlpubs.nist.gov/nistpubs/specialpublications/NIST.SP.800-207.pdf>`_ and aiming at implementing a fully auditable technology both the Backend and the Client are implemented using only open-source libraries.
 
 Here could be found the Software Bills of Materials: `SBOM <https://github.com/globaleaks/globaleaks-whistleblowing-software/dependency-graph/sbom>`_.
 
@@ -42,7 +42,7 @@ The system implements the following password security measures:
 
 Password storage
 ----------------
-Passwords are never stored on the server either in plaintext or in form on hash; instead, the system maintains only the hash of of a key drived from the user password.
+Passwords are never stored on the server either in plaintext or in form on hash; instead, the system maintains only the hash of a key derived from the user password.
 
 Passwords are hashed using `Argon2 <https://en.wikipedia.org/wiki/Argon2>`_ with a configuration of 16 iterations and 128MB of RAM, a per-user salt for each user and a per-system salt for whistleblowers.
 
@@ -400,9 +400,9 @@ Implemented thresholds are:
    "threshold_reports_per_hour_per_ip", "Limit the number of reports that can be filed per hour by the same IP address", "10", "BLOCK"
    "threshold_reports_per_hour_per_tenant_per_ip", "Limit the number of reports that can be filed per hour per tenant by the same IP address", "5", "BLOCK"
    "threshold_attachments_per_hour_per_report", "Limit the number of attachments that can be uploaded per hour on a report", "30", "DELAY"
-   "threshold_operations_per_hour_per_report", "Limit the number of oprations that can be performed per hour on a report", "30", "DELAY"
-   "threshold_operations_per_minute_per_report", "Limit the number of oprations that can be performed per minute on a report", "20", "DELAY"
-   "threshold_operations_per_second_per_report", "Limit the number of oprations that can be performed per second on a report", "1", "DELAY"
+   "threshold_operations_per_hour_per_report", "Limit the number of operations that can be performed per hour on a report", "30", "DELAY"
+   "threshold_operations_per_minute_per_report", "Limit the number of operations that can be performed per minute on a report", "20", "DELAY"
+   "threshold_operations_per_second_per_report", "Limit the number of operations that can be performed per second on a report", "1", "DELAY"
 
 
 In case of necessity, threshold configurations can be adjusted using the `gl-admin` command as follows:

--- a/documentation/user/admin/index.rst
+++ b/documentation/user/admin/index.rst
@@ -99,7 +99,7 @@ User options
 
 Questionnaires
 --------------
-The softare implements a standard default questionnaire that is proposed as a good base for a generic whistleblowing procedure. This questinnaire is the current result of the research performed by the project team with the organizations that have adopted the solution and expecially with anticorruption and investigative journalism NGOs.
+The software implements a standard default questionnaire that is proposed as a good base for a generic whistleblowing procedure. This questionnaire is the current result of the research performed by the project team with the organizations that have adopted the solution and especially with anticorruption and investigative journalism NGOs.
 
 As every organization has different needs, risks and goals globaleaks has been designed considering to implement an advanced questionnaire builder offering the possibility to design custom questionnaires.
 


### PR DESCRIPTION
- Correct repository directory name after git clone (GlobaLeaks/ -> globaleaks-whistleblowing-software/) across all paths in environment.rst
- Remove non-existent grunt copy:sources task from client setup
- Fix duplicate word: 'migrated migrated' -> 'migrated' in update.rst
- Fix 'lates' -> 'latest' in update.rst
- Fix 'meand' -> 'means' in release-procedure.rst
- Fix 'technlogy' -> 'technology' in application-security.rst
- Fix 'hash of of a key drived' -> 'hash of a key derived' in application-security.rst
- Fix 'oprations' -> 'operations' (x3) in application-security.rst
- Fix 'continous' -> 'continuous' in continuous-integration.rst
- Fix 'softare' -> 'software', 'questinnaire' -> 'questionnaire', 'expecially' -> 'especially' in admin/index.rst
- Fix 'is thank to' -> 'is thanks to' in index.rst
- Minor prose fixes: capitalisation of GlobaLeaks, wording cleanup


