### PR TITLE
Improve upload time estimate formatting

### DIFF
--- a/client/app/assets/data_src/texts.txt
+++ b/client/app/assets/data_src/texts.txt
@@ -512,7 +512,9 @@ Your report was successful.
 Your whistleblowing platform is almost ready!
 days
 file unavailable
+hours
 megabytes
+minutes
 percentage
 please enter a valid email address.
 please enter numbers only.

--- a/client/app/src/shared/partials/rfiles-upload-status/r-files-upload-status.component.html
+++ b/client/app/src/shared/partials/rfiles-upload-status/r-files-upload-status.component.html
@@ -9,9 +9,9 @@
     <div>
       <span>{{'Estimated upload time:'|translate}}</span>
       @if (isFinite(estimatedTime)) {
-        <span>{{estimatedTime}}</span>
+        <span>{{getEstimatedTimeValue()}}</span>
       }
-      <span>{{'seconds'|translate}}</span>
+      <span>{{getEstimatedTimeUnit()|translate}}</span>
       @if (progress) {
         <div class="progress progress-striped;active">
           <div class="progress-bar" role="progressbar" [ngStyle]="{width: progress*105 + '%'}"></div>

--- a/client/app/src/shared/partials/rfiles-upload-status/r-files-upload-status.component.ts
+++ b/client/app/src/shared/partials/rfiles-upload-status/r-files-upload-status.component.ts
@@ -14,4 +14,36 @@ export class RFilesUploadStatusComponent {
   @Input() progress: number | undefined;
   @Input() estimatedTime: number | undefined;
   protected readonly isFinite = isFinite;
+
+  protected getEstimatedTimeValue(): number | undefined {
+    if (!this.estimatedTime || !isFinite(this.estimatedTime)) {
+      return this.estimatedTime;
+    }
+
+    if (this.estimatedTime >= 3600) {
+      return Math.ceil(this.estimatedTime / 3600);
+    }
+
+    if (this.estimatedTime >= 60) {
+      return Math.ceil(this.estimatedTime / 60);
+    }
+
+    return Math.ceil(this.estimatedTime);
+  }
+
+  protected getEstimatedTimeUnit(): string {
+    if (!this.estimatedTime || !isFinite(this.estimatedTime)) {
+      return "seconds";
+    }
+
+    if (this.estimatedTime >= 3600) {
+      return "hours";
+    }
+
+    if (this.estimatedTime >= 60) {
+      return "minutes";
+    }
+
+    return "seconds";
+  }
 }


### PR DESCRIPTION
## Summary
This PR improves the file uploader estimated time display by formatting large estimates in minutes or hours instead of always showing seconds.

## Changes
- Show upload estimates below 60 seconds in seconds.
- Show upload estimates from 60 seconds up to 1 hour in minutes.
- Show upload estimates of 1 hour or more in hours.
- Add `minutes` and `hours` to the translation source text list.

## Testing
- Ran `git diff --check`.
