### PR TITLE
docs: clarify local vs remote IP instructions in initialization guide

### DIFF
--- a/documentation/setup/initialization.rst
+++ b/documentation/setup/initialization.rst
@@ -2,9 +2,13 @@ Initialization
 ==============
 After installing GlobaLeaks, you can proceed with the platform wizard.
 
-Open a browser at port 443 on your remote or local IP, respectively.
++Open a browser and navigate to port 443 on your server's address: use its
++local IP if you are connecting from the same machine or network, or its
++public/remote IP if you are connecting from elsewhere. For better
++anonymity, we recommend connecting via the Tor onion address provided at
++the end of the installation, or via ``localhost`` over a VPN.
 
-We recommend accessing using either the Tor address provided at the end of the installation or on localhost via a VPN.
+
 
 Choose the primary language for your site
 -----------------------------------------


### PR DESCRIPTION
Before submitting a pull request, please ensure the following:

- [x] The pull request includes a description of the problem you're trying to solve.
- [x] The pull request provides an overview of the suggested solution.
- [x] The proposed code is fully functional.
- [ ] The proposed code includes relevant tests to verify its functionality.
- [ ] All new and existing tests pass successfully.
- [ ] Overall code quality and test coverage metrics are not reduced by more than 0.5%

+ What this fixes

The original instruction — "Open a browser at port 443 on your remote or 
local IP, respectively" — was unclear, since "respectively" implies a 
pairing that isn't established anywhere earlier in the doc. New users 
following the setup guide had no clear way to tell which IP (local or 
remote) applies to their situation.

+ Change

Rewrote the instruction to explicitly state when to use a local IP 
(same machine/network) versus a public/remote IP (connecting from 
elsewhere), and lightly reworded the Tor/VPN recommendation for clarity.

+ Related issue

Addresses part of #4429 (Improve Globaleaks Documentation)

+ Type of change
- [x] Documentation
- [ ] Bug fix
- [ ] New feature 

Note: this is a documentation-only change (no code/tests affected — 
items 4-6 in the checklist are N/A).