### PR TITLE
Bump dompurify from 3.4.12 to 3.4.13 (GHSA-55q2-fjhq-7xh7)

### DIFF
--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -11102,9 +11102,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,7 @@
     "angularx-qrcode": "21.0.5",
     "bootstrap": "5.3.8",
     "chart.js": "4.5.1",
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "libsodium-wrappers-sumo": "0.8.4",
     "marked": "18.0.7",
     "ng-multiselect-dropdown": "1.0.0",


### PR DESCRIPTION
Bumps dompurify from 3.4.12 to 3.4.13 to resolve GHSA-55q2-fjhq-7xh7.

**Vulnerability:** DOMPurify IN\_PLACE hook removal leaves a detached subtree executable, causing XSS (Medium severity, CWE-79).

In versions ≤ 3.4.12, when `IN_PLACE` sanitization is used with an element-removal hook (e.g. `uponSanitizeElement`), the early return on hook-detachment skips `_neutralizeSubtree()`. A detached descendant resource element can retain its event handler and execute after `sanitize()` returns.

**Fix:** 3.4.13 calls `_neutralizeSubtree(currentNode)` before returning from hook-detachment branches in `_sanitizeElements()`.

**Changes:**
- `client/package.json`: dompurify 3.4.12 → 3.4.13
- `client/npm-shrinkwrap.json`: updated version, resolved URL, and integrity hash

No changes to application logic or source behavior. Only dependency manifest and lockfile.