### PR TITLE
Log permanent attachment deletion in the audit log

### DIFF
--- a/backend/globaleaks/handlers/recipient/rtip.py
+++ b/backend/globaleaks/handlers/recipient/rtip.py
@@ -1322,12 +1322,15 @@ def update_redaction(session, tid, user_id, redaction_id, redaction_data, tip_da
 
                 db_log(session, tid=tid, type='update_redaction', user_id=user_id, object_id=redaction.id, data=log_data)
 
+                file_id = redaction.reference_id
                 if session.query(models.ReceiverFile) \
-                          .filter(models.ReceiverFile.id == redaction.reference_id).count():
-                    db_delete_rfile(session, tid, user_id, redaction.reference_id)
+                          .filter(models.ReceiverFile.id == file_id).count():
+                    db_delete_rfile(session, tid, user_id, file_id)
                 else:
-                    delete_wbfile(session, tid, user_id, redaction.reference_id)
+                    delete_wbfile(session, tid, user_id, file_id)
 
+                db_log(session, tid=tid, type='delete_file', user_id=user_id,
+                       object_id=file_id, data={'internaltip_id': itip.id})
                 session.delete(redaction)
         elif content_type == 'whistleblower_identity':
             db_redact_whistleblower_identity(session, tid, user_id, itip, redaction, redaction_data, tip_data)

--- a/backend/globaleaks/tests/handlers/recipient/test_file_deletion_audit.py
+++ b/backend/globaleaks/tests/handlers/recipient/test_file_deletion_audit.py
@@ -1,0 +1,74 @@
+from twisted.internet.defer import inlineCallbacks
+
+from globaleaks import models
+from globaleaks.handlers.recipient import rtip
+from globaleaks.jobs.delivery import Delivery
+from globaleaks.orm import transact
+from globaleaks.tests import helpers
+
+
+@transact
+def get_delete_file_logs(session, file_id):
+    return [
+        {
+            'user_id': log.user_id,
+            'object_id': log.object_id,
+            'data': log.data
+        }
+        for log in session.query(models.AuditLog)
+                          .filter(models.AuditLog.type == 'delete_file',
+                                  models.AuditLog.object_id == file_id)
+                          .all()
+    ]
+
+
+class TestFileDeletionAudit(helpers.TestHandlerWithPopulatedDB):
+    _handler = rtip.RTipRedactionCollection
+
+    @inlineCallbacks
+    def setUp(self):
+        yield helpers.TestHandlerWithPopulatedDB.setUp(self)
+        yield self.perform_full_submission_actions()
+        yield Delivery().run()
+
+    @inlineCallbacks
+    def test_permanent_file_redaction_is_audited_as_deletion(self):
+        rtip_desc = (yield self.get_rtips())[0]
+        receiver_id = rtip_desc['receiver_id']
+        itip_id = rtip_desc['id']
+        file_id = (yield self.get_wbfiles(rtip_desc['rtip_id']))[0]
+
+        body = {
+            'internaltip_id': itip_id,
+            'reference_id': file_id,
+            'entry': '0',
+            'permanent_redaction': '',
+            'temporary_redaction': [{'start': '-inf', 'end': 'inf'}]
+        }
+        handler = self.request(body, role='receiver', user_id=receiver_id)
+        yield handler.post()
+
+        rtip_desc = next(rtip_desc for rtip_desc in (yield self.get_rtips())
+                         if rtip_desc['id'] == itip_id and rtip_desc['receiver_id'] == receiver_id)
+        redaction = next(redaction for redaction in rtip_desc['redactions']
+                         if redaction['reference_id'] == file_id)
+
+        body = {
+            'id': redaction['id'],
+            'operation': 'redact',
+            'content_type': 'file',
+            'internaltip_id': itip_id,
+            'reference_id': file_id,
+            'entry': '0',
+            'permanent_redaction': [],
+            'temporary_redaction': [{'start': '-inf', 'end': 'inf'}]
+        }
+        handler = self.request(body, role='receiver', user_id=receiver_id)
+        yield handler.put(redaction['id'])
+
+        logs = yield get_delete_file_logs(file_id)
+        self.assertEqual(logs, [{
+            'user_id': receiver_id,
+            'object_id': file_id,
+            'data': {'internaltip_id': itip_id}
+        }])


### PR DESCRIPTION
## Summary

When a recipient permanently redacts a masked attachment, the file is deleted but the audit log currently only records `update_redaction`.

This change adds a separate `delete_file` audit entry for that permanent deletion.

The new audit entry records:

- the recipient who performed the deletion
- the deleted file ID
- the associated report ID

The existing `update_redaction` audit entry is preserved.

This does not change deletion behavior, permissions, or redaction logic. It only makes the destructive file deletion explicitly visible in the audit trail.

## Testing

Added a regression test covering permanent deletion of a masked attachment.

The test verifies that:

- the file is permanently deleted
- exactly one `delete_file` audit entry is created
- the audit entry contains the expected user ID
- the audit entry identifies the deleted file
- the audit entry references the correct report

Fixes #4894